### PR TITLE
Return h.continue instead of response

### DIFF
--- a/index.js
+++ b/index.js
@@ -83,7 +83,7 @@ exports.plugin = {
       var response = request.response;
 
       if (Boom.isBoom(response)) {
-        return response;
+        return h.continue;
       }
 
       if (response.variety === 'view') {


### PR DESCRIPTION
Returning a response object here halt execution of other plugins that may listen to the `onPreResponse` event.
There is no reason i18n should prevent other plugins from logging 404 or other errors.

I ran into this problem when updating a project from HAPI v16. I worked around it by loading the plugin which listens to 404 errors before hapi-i18n but this PR should fix such problems.